### PR TITLE
Feature/wallet testing procedure

### DIFF
--- a/.github/ISSUE_TEMPLATE/WALLET-TEST.yml
+++ b/.github/ISSUE_TEMPLATE/WALLET-TEST.yml
@@ -1,0 +1,57 @@
+name: Wallet Test Submission
+description: Submit your report of a wallet, exchange, or other bitcoin service for compatibility with unified BIP21 QR codes
+title: "[Wallet Test]: "
+labels: ["wallet-test"]
+assignees:
+  - sbddesign
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: wallet_name
+    attributes:
+      label: App Name
+      description: The name of the wallet, exchange, or service provider you tested
+      placeholder: ex. Boss Wallet
+  - type: input
+    id: wallet_uri
+    attributes:
+      label: App Website
+      description: The website of the wallet, exchange, or service provider you tested
+      placeholder: ex. bosswallet3000.com
+  - type: dropdown
+    id: scans_bip21
+    attributes:
+      label: Scans BIP-21
+      description: Did the wallet successfully scan the BIP21 QR code?
+      options:
+        - Yes
+        - No
+  - type: dropdown
+    id: recognizes_lightning
+    attributes:
+      label: Recognize Lightning
+      description: Did the wallet recognize the BOLT 11 invoice in the BIP-21 QR code?
+      options:
+        - Yes
+        - No
+        - Not applicable - the wallet doesn't support Lightning
+  - type: dropdown
+    id: creates_bip21
+    attributes:
+      label: Creates BIP-21 QR codes
+      description: Is the wallet capable of creating BIP-21 QR codes when the user wants to request a payment? This is not common!
+      options:
+        - Yes (more common)
+        - No
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Optional - describe what happened. For example, if it failed to scan, you would include the error message the app gave you here.
+      placeholder: The wallet said "can't scan because this is not a valid lightning invoice"...
+      value: ""
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -4,31 +4,7 @@ This is a WIP microsite to promote the usage of a BIP21 payment URI QR code that
 
 ## Wallet support
 
-| Wallet        | BIP21 support     | Recognizes Lightning | Description | Issue |
-|--------------|-----------|------------|------------|------------|
-| Alby | ❌ | ❌ |   |
-| Bitcoin Beach | ✔️ | ❌ |   |        
-| Blixt | ✔️ | ✔️ | QR code is not a valid bitcoin lightning invoice. |          
-| Bluewallet | ✔️ | ✔️ |  Asks to select a wallet, and I can choose my lightning wallet or on-chain wallet. |          
-| Breez | ✔️ | ✔️ |  |          
-| BitPay | ✔️ | N/A |   |         
-| Casa  | ✔️ | N/A |            
-| Cash App  | ✔️ | ❌ | Takes user to PIN entry followed by on-chain TX fee selection. |           
-| Chaincase | ✔️ | N/A | Pulls in the entire string including the 'bitcoin:', but I think it sees it as an on-chain address. |            
-| Coinbase |   |    |  |  
-| Edge Wallet  | ✔️ | N/A | Can decode the QRcode that contains a BIP21 URI with bolt11 and the external onchain fallback. The URI can also be pasted, the onchain address is detected and users can send |
-| Electrum |  |  |  |
-| Green wallet |  |   |
-| Muun | ✔️ | ✔️  |            |  |
-| Nunchuk |  |   |  |
-| Phoenix | ✔️ | ✔️ |   |
-| Samourai | ✔️ | N/A |  |
-| Simple Bitcoin Wallet | ✔️ | ✔️ | Needed a channel open to test but seemed to read the invoice. |
-| Strike | ✔️ | ❌ | "Amount is too low" I think it is defaulting to on-chain. |           
-| Wallet of Satoshi | ✔️ | ✔️  |  |            
-| Zap |  |  |   |
-| Zebedee | ❌ | ❌ | "This looks like an on-chain QR code..." |            
-| Zeus | ✔️ | ❌ |   |  [Link](https://github.com/ZeusLN/zeus/issues/879)
+See the [Support table](https://bitcoinqr.dev/#support) on this website. If you'd like to update the data in this table, you can edit the [`wallet.json`](https://github.com/sbddesign/bip21-site/blob/main/wallet_support.json) file in a PR or [submit an issue](https://github.com/sbddesign/bip21-site/issues/new).
 
 ## Getting Started
 

--- a/wallet_support.json
+++ b/wallet_support.json
@@ -72,6 +72,21 @@
   },
   {
     "wallet": {
+      "name": "Blockstream Green",
+      "uri": "https://blockstream.com/green/"
+    },
+    "scans_bip21": "",
+    "recognizes_lightning": "",
+    "creates_bip21": "",
+    "description": "",
+    "notes": "",
+    "credit": {
+      "name": "",
+      "uri": ""
+    }
+  },
+  {
+    "wallet": {
       "name": "Bluewallet",
       "uri": "https://bluewallet.io/"
     },
@@ -221,6 +236,21 @@
   },
   {
     "wallet": {
+      "name": "Nunchuk",
+      "uri": "https://nunchuk.io/"
+    },
+    "scans_bip21": "",
+    "recognizes_lightning": "",
+    "creates_bip21": "",
+    "description": "",
+    "notes": "",
+    "credit": {
+      "name": "",
+      "uri": ""
+    }
+  },
+  {
+    "wallet": {
       "name": "OKCoin",
       "uri": "https://www.okcoin.com/"
     },
@@ -243,6 +273,36 @@
     "credit": {
       "name": "@sbddesign",
       "uri": "https://github.com/sbddesign"
+    }
+  },
+  {
+    "wallet": {
+      "name": "Samourai",
+      "uri": "https://samouraiwallet.com/"
+    },
+    "scans_bip21": "yes",
+    "recognizes_lightning": "yes",
+    "creates_bip21": "",
+    "description": "Needed a channel open to test but seemed to read the invoice.",
+    "notes": "",
+    "credit": {
+      "name": "@bosch",
+      "uri": "https://github.com/Bosch-0"
+    }
+  },
+  {
+    "wallet": {
+      "name": "Simple Bitcoin Wallet",
+      "uri": ""
+    },
+    "scans_bip21": "yes",
+    "recognizes_lightning": "yes",
+    "creates_bip21": "",
+    "description": "Needed a channel open to test but seemed to read the invoice.",
+    "notes": "",
+    "credit": {
+      "name": "@bosch",
+      "uri": "https://github.com/Bosch-0"
     }
   },
   {
@@ -270,6 +330,21 @@
     "creates_bip21": "",
     "description": "",
     "notes": ""
+  },
+  {
+    "wallet": {
+      "name": "Zap",
+      "uri": "https://zaphq.io/"
+    },
+    "scans_bip21": "",
+    "recognizes_lightning": "",
+    "creates_bip21": "",
+    "description": "",
+    "notes": "",
+    "credit": {
+      "name": "",
+      "uri": ""
+    }
   },
   {
     "wallet": {


### PR DESCRIPTION
We have a situation where some of us editing the README.md file and some of us are editing the wallet_support.json file. To simplify things, I propose we remove the wallet support table from the Readme and just use the JSON file moving forward, that way the nice website front-end always displays what is current. Single source of truth.

What I did:
- Added an issue template form for adding a wallet or service to the table (good for people who don't like updating code, this will basically make a form they fill out)
- Merged readme and wallet JSON data
- Removed wallet data from readme to avoid redundancy