### PR TITLE
Add btcpayserver

### DIFF
--- a/wallet_support.json
+++ b/wallet_support.json
@@ -208,11 +208,15 @@
       "name": "Electrum",
       "uri": "https://electrum.org/"
     },
-    "scans_bip21": "",
-    "recognizes_lightning": "",
-    "creates_bip21": "",
+    "scans_bip21": "yes",
+    "recognizes_lightning": "yes",
+    "creates_bip21": "no",
     "description": "",
-    "notes": ""
+    "notes": "",
+     "credit": {
+      "name": "@bitkarrot",
+      "uri": "https://github.com/bitkarrot"
+    }
   },
   {
     "wallet": {

--- a/wallet_support.json
+++ b/wallet_support.json
@@ -118,6 +118,21 @@
   },
   {
     "wallet": {
+      "name": "BTCPay Server",
+      "uri": "https://btcpayserver.org/"
+    },
+    "scans_bip21": "no",
+    "recognizes_lightning": "?",
+    "creates_bip21": "no",
+    "description": "",
+    "notes": "",
+    "credit": {
+      "name": "@bitkarrot",
+      "uri": "https://github.com/bitkarrot"
+    }
+  },
+  {
+    "wallet": {
       "name": "Casa",
       "uri": "https://keys.casa/"
     },

--- a/wallet_support.json
+++ b/wallet_support.json
@@ -212,7 +212,8 @@
     "recognizes_lightning": "yes",
     "creates_bip21": "no",
     "description": "",
-    "notes": "",
+      "notes": "",
+      "issue_link": "https://github.com/spesmilo/electrum/issues/7253",
      "credit": {
       "name": "@bitkarrot",
       "uri": "https://github.com/bitkarrot"


### PR DESCRIPTION
Btcpay Server separates all Bitcoin and Lightning QR codes into 2 tabs. The user has to actively select which method in the UI. Since Btcpay Server's focus is on receiving payments,  generating it's own BIP21 QR code would be the primary area for development. 

As for outgoing payments from Btcpay, these would be signed by PSBT or a hardware wallet via Btcpay admin panel or via the Greenfield API https://docs.btcpayserver.org/API/Greenfield/v1/. Neither of these are end user facing and currently don't require scanning of QR codes. As for the future, Its not clear if scanning QR codes would be need to be implemented in admin panel. 

After doing a search, there is no mention of Bip 21 in the btcpayserver repository. 
