### PR TITLE
Updated Strike

### DIFF
--- a/wallet_support.json
+++ b/wallet_support.json
@@ -458,10 +458,10 @@
     "creates_bip21": "no",
     "description": "Strike has been updated to recognize the lightning param after scanning",
     "notes": "",
-    "issue_link": "https://twitter.com/StephenDeLorme/status/1504207670567395330",
+    "issue_link": "",
     "credit": {
-      "name": "Strike Team",
-      "uri": ""
+      "name": "@sbddesign, manuela, verbiricha",
+      "uri": "https://github.com/sbddesign/bip21-site/pull/72#issue-1387877559"
     }
   },
   {


### PR DESCRIPTION
[I tested Strike earlier in the year](https://twitter.com/StephenDeLorme/status/1504207670567395330) and found that it could scan a BIP21 QR, but did not recognize the `lightning` param.

Thanks [manuela](https://twitter.com/yorios9312) and [verbiricha](https://bitcoindesign.slack.com/archives/C034NQNLN85/p1664200042465149) for pointing out this has now been updated to recognize the `lightning` param.

