### PR TITLE
Update wallet_support.json (Add Wasabi Wallet)

### DIFF
--- a/wallet_support.json
+++ b/wallet_support.json
@@ -498,6 +498,22 @@
   },
   {
     "wallet": {
+      "name": "Wasabi Wallet",
+      "uri": "https://wasabiwallet.io/"
+    },
+    "scans_bip21": "yes",
+    "recognizes_lightning": "no",
+    "creates_bip21": "no",
+    "description": "Scans BIP21 QR codes but doesn't recognize lightning addresses. Doesn't generate BIP21 QR code",
+    "notes": "Currently QR code scanning works on Windows only",
+    "issue_link": "https://github.com/zkSNACKs/WalletWasabi/issues/4259",
+    "credit": {
+      "name": "@yahiheb",
+      "uri": "https://github.com/yahiheb"
+    }
+  },
+  {
+    "wallet": {
       "name": "Zebedee",
       "uri": "https://zebedee.io/"
     },

--- a/wallet_support.json
+++ b/wallet_support.json
@@ -505,7 +505,7 @@
     "recognizes_lightning": "n/a",
     "creates_bip21": "no",
     "description": "Scans BIP21 QR codes but doesn't recognize lightning addresses. Doesn't generate BIP21 QR code",
-    "notes": "Currently QR code scanning works on Windows only",
+    "notes": "Currently QR code scanning doesn't work on macOS",
     "issue_link": "https://github.com/zkSNACKs/WalletWasabi/issues/4259",
     "credit": {
       "name": "@yahiheb",

--- a/wallet_support.json
+++ b/wallet_support.json
@@ -502,7 +502,7 @@
       "uri": "https://wasabiwallet.io/"
     },
     "scans_bip21": "yes",
-    "recognizes_lightning": "no",
+    "recognizes_lightning": "n/a",
     "creates_bip21": "no",
     "description": "Scans BIP21 QR codes but doesn't recognize lightning addresses. Doesn't generate BIP21 QR code",
     "notes": "Currently QR code scanning works on Windows only",


### PR DESCRIPTION
Fixes https://github.com/sbddesign/bip21-site/issues/37

Currently Wasabi Wallet can scan BIP21 QR codes (Windows only) but cannot recognize lightning addresses and it doesn't generate BIP21 QR code.

![Capture](https://user-images.githubusercontent.com/52379387/231617927-dc5ed2e5-18e6-48b2-8a07-546dd3ff8f60.PNG)
