### PR TITLE
Add BitBanana

### DIFF
--- a/wallet_support.json
+++ b/wallet_support.json
@@ -1,22 +1,6 @@
 [
   {
     "wallet": {
-      "name": "Zap",
-      "uri": "https://zaphq.io/"
-    },
-    "scans_bip21": "yes",
-    "recognizes_lightning": "yes",
-    "creates_bip21": "no",
-    "description": "Zap defaults to on-chain if the included invoice is expired, but it recognizes Lightning when the invoice is still valid.",
-    "issue_link": "https://github.com/LN-Zap/zap-android/pull/273",
-    "notes": "",
-    "credit": {
-      "name": "@velaia",
-      "uri": "https://github.com/velaia"
-    }
-  },
-  {
-    "wallet": {
       "name": "Binance",
       "uri": "https://www.binance.com/"
     },
@@ -671,6 +655,21 @@
     "credit": {
       "name": "@thisispav",
       "uri": "https://github.com/thisispav"
+    }
+  },
+  {
+    "wallet": {
+      "name": "BitBanana",
+      "uri": "https://bitbanana.app/"
+    },
+    "scans_bip21": "yes",
+    "recognizes_lightning": "yes",
+    "creates_bip21": "no",
+    "description": "Bitbanana defaults to on-chain if the included invoice is expired, but it recognizes Lightning when the invoice is still valid.",
+    "notes": "",
+    "credit": {
+      "name": "@MichaelWuensch",
+      "uri": "https://github.com/michaelWuensch"
     }
   }
 ]


### PR DESCRIPTION
This PR adds BitBanana to the list. 
It also removes Zap, which was in fact a test of Zap Android.
BitBanana is the successor of Zap Android. I am the developer of former Zap Android and now BitBanana. All Zap development was discontinued years ago, so I think it is time to remove it from the list.