### PR TITLE
Add entry for SeedSigner

### DIFF
--- a/wallet_support.json
+++ b/wallet_support.json
@@ -489,6 +489,21 @@
   },
   {
     "wallet": {
+      "name": "SeedSigner",
+      "uri": "https://seedsigner.com"
+    },
+    "scans_bip21": "yes",
+    "recognizes_lightning": "n/a",
+    "creates_bip21": "n/a",
+    "description": "Scans BIP21 QR codes that contain an onchain address.",
+    "notes": "",
+    "credit": {
+      "name": "@kdmukai",
+      "uri": "https://github.com/kdmukai"
+    }
+  },
+  {
+    "wallet": {
       "name": "Simple Bitcoin Wallet",
       "uri": ""
     },


### PR DESCRIPTION
Verified that SeedSigner can read BIP21 QR codes that contain an onchain address.

It correctly ignores any additional params or added formats that we don't support (e.g. anything LN) when extracting the onchain addr.